### PR TITLE
Make wp_list_pages query filterable.

### DIFF
--- a/wp-help.php
+++ b/wp-help.php
@@ -634,7 +634,7 @@ class CWS_WP_Help_Plugin {
 		if ( $with_sort_handles )
 			$this->filter_wp_list_pages = true;
 		$defaults = array( 'post_type' => self::POST_TYPE, 'hierarchical' => true, 'echo' => false, 'title_li' => '' );
-		$output = trim( wp_list_pages( wp_parse_args( apply_filters( 'cws_wp_help_list_pages_args', $args ), $defaults ) ) );
+		$output = trim( wp_list_pages( apply_filters( 'cws_wp_help_list_pages', $defaults ) ) );
 		$this->filter_wp_list_pages = false;
 		return $output;
 	}


### PR DESCRIPTION
It would be nice to make the wp_list_pages() query filterable so, for instance, I can filter based on post meta or other args.

I tried to follow your style so the wp_parse_args got bundled in with the trim on line 637. Could split it out as its own line if you favor readability over succinctness.
