### PR TITLE
Rename methods to prevent warnings

### DIFF
--- a/lib/requirements-check.php
+++ b/lib/requirements-check.php
@@ -29,7 +29,7 @@ class CWS_WP_Help_Requirements_Check {
 	}
 
 	private function php_passes() {
-		if ( $this->__php_at_least( $this->php ) ) {
+		if ( $this->php_at_least( $this->php ) ) {
 			return true;
 		} else {
 			add_action( 'admin_notices', array( $this, 'php_version_notice' ) );
@@ -37,7 +37,7 @@ class CWS_WP_Help_Requirements_Check {
 		}
 	}
 
-	private static function __php_at_least( $min_version ) {
+	private static function php_at_least( $min_version ) {
 		return version_compare( phpversion(), $min_version, '>=' );
 	}
 
@@ -48,7 +48,7 @@ class CWS_WP_Help_Requirements_Check {
 	}
 
 	private function wp_passes() {
-		if ( $this->__wp_at_least( $this->wp ) ) {
+		if ( $this->wp_at_least( $this->wp ) ) {
 			return true;
 		} else {
 			add_action( 'admin_notices', array( $this, 'wp_version_notice' ) );
@@ -56,7 +56,7 @@ class CWS_WP_Help_Requirements_Check {
 		}
 	}
 
-	private static function __wp_at_least( $min_version ) {
+	private static function wp_at_least( $min_version ) {
 		return version_compare( get_bloginfo( 'version' ), $min_version, '>=' );
 	}
 


### PR DESCRIPTION
Removed the double underscore prefix from 2 methods to prevent warnings:

40 | WARNING | Method name
"CWS_WP_Help_Requirements_Check::__php_at_least" is discouraged; PHP has
reserved all method names with a double underscore prefix for future
use\
 59 | WARNING | Method name
"CWS_WP_Help_Requirements_Check::__wp_at_least" is discouraged; PHP has
reserved all method names with a double underscore prefix for future
use\