### PR TITLE
Solve notice: Trying to get property 'id' of non-object

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -104,7 +104,7 @@ class CWS_WP_Help_Plugin {
 			'is_default_doc',
 			array(
 				'get_callback' => function ( $doc ) {
-					return $this->is_default_doc( $doc->id );
+					return $this->is_default_doc( $doc['id'] );
 				},
 				'update_callback' => function ( $value, WP_Post $doc ) {
 					if ( $this->is_default_doc( $doc ) && ! $value ) {


### PR DESCRIPTION
Hello @markjaquith! Thanks for your plugin.

I'm using it in https://www.outnowon.com/, a tool to help musicians. I also use Sentry for bug tracking and I've detected a notice that says:

![Screenshot from 2020-07-02 15-14-18](https://user-images.githubusercontent.com/2051540/86363183-c70e7e00-bc76-11ea-993a-15f53840a393.png)

I've checked the documentation for get_callback argument of register_rest_field in https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/#examples and it's using an array to access the data.

I am using WordPress 5.4.2 and wp-help 1.7.0.


