### PR TITLE
Make 'Default Help Document' label translatable

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -127,6 +127,7 @@ class CWS_WP_Help_Plugin {
 		if ( self::is_block_editor() && self::POST_TYPE === get_post_type() ) {
 			$asset = $this->include_file( '/dist/block-editor.asset.php' );
 			wp_enqueue_script( 'cws-wp-block-editor', $this->get_url() . 'dist/block-editor.js', $asset['dependencies'], $asset['version'], true );
+			wp_set_script_translations( 'cws-wp-block-editor', 'wp-help' );
 			wp_dequeue_style( 'twentytwenty-block-editor-styles' );
 		}
 	}

--- a/src/block-editor.js
+++ b/src/block-editor.js
@@ -3,6 +3,7 @@ import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { PluginPostStatusInfo } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
 
 const DEFAULT_DOCUMENT = 'is_default_doc';
 
@@ -21,7 +22,7 @@ function WpHelp({ isDefault, setDefaultDocument }) {
 	return (
 		<PluginPostStatusInfo>
 			<CheckboxControl
-				label="Default Help Document"
+				label={__('Default Help Document', 'wp-help')}
 				checked={isDefault}
 				onChange={setDefaultDocument}
 			/>


### PR DESCRIPTION
Fixes #42.
See #31.