### PR TITLE
Remove duplicate $instance property

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -4,7 +4,6 @@ defined( 'WPINC' ) or die;
 class CWS_WP_Help_Plugin {
 	use WP_Help_Plugin_Structure;
 
-	protected static $instance;
 	protected $options;
 	protected $admin_base = '';
 	protected $help_topics_html;


### PR DESCRIPTION
Fixes #35.

It's already defined by `WP_Help_Plugin_Structure`.