### PR TITLE
Don't copy yarn-error.log to release directory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,7 @@ const ignores = [
 	'!cypress.*',
 	'!phpcs.xml',
 	'!phpunit.xml.dist',
+	'!yarn-error.log',
 ];
 
 function cleanUpReleaseFiles() {


### PR DESCRIPTION
If a previous yarn task has failed a `yarn-error.log` file gets created which may accidentally be copied to the release directory.