### PR TITLE
Improve config for PHP_CodeSniffer

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,20 @@
 <ruleset name="Slightly relaxed WordPress coding standards">
 	<description>Based on the WordPress coding standards</description>
 
+	<file>.</file>
+
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
+
+	<!-- Check up to 20 files simultaneously. -->
+	<arg name="parallel" value="20"/>
+
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
+	<arg name="cache"/>
+
 	<rule ref="PHPCompatibility"/>
 	<config name="testVersion" value="7.0-"/>
 
@@ -24,4 +38,13 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- Will uncomment this when I start requiring PHP 5.4+ in 2019 -->
 	<!--<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>-->
+
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>/templates/*</exclude-pattern>
+	</rule>
+
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/release/*</exclude-pattern>
+	<exclude-pattern>/dist/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
Without this, running `phpcs .` results in OOM fatal errors.

Current status:
```
❯ phpcs --report=summary --basepath=.
EEEEEEEEEEE 11 / 11 (100%)



PHP CODE SNIFFER REPORT SUMMARY
----------------------------------------------------------------------
FILE                                                  ERRORS  WARNINGS
----------------------------------------------------------------------
wp-help.php                                           2       0
classes/plugin.php                                    275     35
lib/requirements-check.php                            23      2
lib/structure.php                                     25      1
templates/dashboard-widget.php                        1       0
templates/edit-page-js.php                            1       0
templates/list-documents.php                          10      0
templates/settings.php                                4       0
templates/submitbox-actions.php                       1       1
tests/bootstrap.php                                   15      0
tests/utils-test.php                                  3       0
----------------------------------------------------------------------
A TOTAL OF 360 ERRORS AND 39 WARNINGS WERE FOUND IN 11 FILES
----------------------------------------------------------------------
PHPCBF CAN FIX 207 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------

Time: 224ms; Memory: 12MB
```