### PR TITLE
Avoid PHP notice by checking that the CPT exists

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -213,7 +213,12 @@ class CWS_WP_Help_Plugin {
 	}
 
 	protected function get_cap( $cap ) {
-		return get_post_type_object( self::POST_TYPE )->cap->{$cap};
+		$post_type_object = get_post_type_object( self::POST_TYPE );
+		if ( ! $post_type_object ) {
+			return 'do_not_allow';
+		}
+
+		return $post_type_object->cap->{$cap};
 	}
 
 	public function action_links( $links ) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/617637/89288602-356ba500-d656-11ea-9107-d16eb91f876b.png)

The notices can occur if the current user doesn't have the view capability, see https://github.com/markjaquith/wp-help/blob/89cbbf87e6ae3cc081b69162cba2e8c63586f53b/classes/plugin.php#L85-L87