### PR TITLE
Allow to create new documents from the admin toolbar

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -143,15 +143,16 @@ class CWS_WP_Help_Plugin {
 	protected function register_post_type() {
 		register_post_type( self::POST_TYPE,
 			array(
-				'label'        => _x( 'Publishing Help', 'post type label', 'wp-help' ),
-				'public'       => false,
-				'show_ui'      => true,
-				'show_in_menu' => false,
-				'show_in_rest' => true,
-				'hierarchical' => true,
-				'supports'     => array( 'title', 'editor', 'revisions', 'page-attributes' ),
-				'map_meta_cap' => true,
-				'capabilities' => array(
+				'label'             => _x( 'Publishing Help', 'post type label', 'wp-help' ),
+				'public'            => false,
+				'show_ui'           => true,
+				'show_in_menu'      => false,
+				'show_in_admin_bar' => true,
+				'show_in_rest'      => true,
+				'hierarchical'      => true,
+				'supports'          => array( 'title', 'editor', 'revisions', 'page-attributes' ),
+				'map_meta_cap'      => true,
+				'capabilities'      => array(
 					// Normally requires 'edit_posts'
 					'read_posts'         => $this->view_cap( 'read_posts'         ),
 


### PR DESCRIPTION
It's currently a bit cumbersome to quickly create a new document. The should be an entry in the Add New toolbar which is currently missing because `show_in_admin_bar` falls back to the value of `show_in_menu` which is set to `false`.  Setting it to `true` restores the item.

To review without the alignment changes you can use https://github.com/markjaquith/wp-help/commit/3f2b2b2977e7201fee363d6022abd755f2904b7c?w=1.